### PR TITLE
translated spelling

### DIFF
--- a/xml/1672/1672_07_14_mm2os.xml
+++ b/xml/1672/1672_07_14_mm2os.xml
@@ -8,7 +8,7 @@
                 <title>lett 4 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_08_01_mm2lc.xml
+++ b/xml/1672/1672_08_01_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 05 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_09_05_a_mm2os.xml
+++ b/xml/1672/1672_09_05_a_mm2os.xml
@@ -8,7 +8,7 @@
                 <title>lett 534 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_09_05_b_mm2os.xml
+++ b/xml/1672/1672_09_05_b_mm2os.xml
@@ -9,7 +9,7 @@
                 <title>lett 535 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_09_09_mm2os.xml
+++ b/xml/1672/1672_09_09_mm2os.xml
@@ -8,7 +8,7 @@
                 <title>lett 9 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_09_23_mm2lc.xml
+++ b/xml/1672/1672_09_23_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 10 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_09_27_mm2lc.xml
+++ b/xml/1672/1672_09_27_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 12 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_10_02_mm2lc.xml
+++ b/xml/1672/1672_10_02_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 8 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_10_29_mm2lc.xml
+++ b/xml/1672/1672_10_29_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 13 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_10_29_mm2os.xml
+++ b/xml/1672/1672_10_29_mm2os.xml
@@ -8,7 +8,7 @@
                 <title>lett 536 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_11_18_n2os.xml
+++ b/xml/1672/1672_11_18_n2os.xml
@@ -8,7 +8,7 @@
                 <title>Nanette to Ortenisa Stella</title>
                 <author key="nanette">Nanette</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_12_02_mm2lc.xml
+++ b/xml/1672/1672_12_02_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 14 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_12_13_mm2lc.xml
+++ b/xml/1672/1672_12_13_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 16 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_12_25_mm2os.xml
+++ b/xml/1672/1672_12_25_mm2os.xml
@@ -8,7 +8,7 @@
                 <title>lett 537 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_12_30_mm2lc.xml
+++ b/xml/1672/1672_12_30_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 17 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1672/1672_mm2lc.xml
+++ b/xml/1672/1672_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 01 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1673/1673_02_07_mm2lc.xml
+++ b/xml/1673/1673_02_07_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 21 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1673/1673_08_04_mm2lc.xml
+++ b/xml/1673/1673_08_04_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 33 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1673/1673_12_29_mm2lc.xml
+++ b/xml/1673/1673_12_29_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 47 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/1674/1674_01_12_mm2lc.xml
+++ b/xml/1674/1674_01_12_mm2lc.xml
@@ -8,7 +8,7 @@
                 <title>lett 48 Marie to Lorenzo</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/letter-example.xml
+++ b/xml/letter-example.xml
@@ -8,7 +8,7 @@
                 <title>lett 4 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>

--- a/xml/letter-template.xml
+++ b/xml/letter-template.xml
@@ -8,7 +8,7 @@
                 <title>lett 4 Marie to Ortenisa Stella</title>
                 <author key="mancini-marie">Marie Mancini</author>
                 <respStmt>
-                    <resp>Transcribed and tanslated by</resp>
+                    <resp>Transcribed and translated by</resp>
                     <name xml:id="smn">Sarah M. Nelson</name>
                 </respStmt>
                 <respStmt>


### PR DESCRIPTION
@owikle PR just corrects a spelling issue (i think?) repeated from the xml template, "tanslated" --> "translated".

Codespell Check extension doesn't check XML by default, but you can add it in the settings.